### PR TITLE
Initialize the results variable.

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -8,7 +8,9 @@ var fs = require("fs"),
     events = require( 'events' );
 
 
-function API(){}
+function API(){
+    results = [];
+}
 
 //inherit from EventEmitter
 require('util').inherits(API, events.EventEmitter);


### PR DESCRIPTION
Hi, when calling logout after login without doing any search, the logout fails with "results undefined" error. Not a big deal, but I got a little bit confused when that happened. So I've added an initialization. Btw, the logout function comment says "resolve with token" but actually it resolves with results, so may be that's a problem too.